### PR TITLE
Serial port prompt function now accepts input of "COMX" type.

### DIFF
--- a/src/emulator_uart.c
+++ b/src/emulator_uart.c
@@ -117,7 +117,7 @@ int com_port_num;
 
 strncpy(com_buf, port_buf, 3);
 
-if(strcmp(com_buf, "COM") == 0){
+if(strncmp(com_buf, "COM", 3) == 0){
     sscanf(port_buf+3, "%d", &com_port_num);
     com_port_num--;
     snprintf(port_buf, 12, "/dev/ttyS%d", com_port_num);


### PR DESCRIPTION
[#16 ](https://github.com/SunDevilRocketry/sdr-emulator/issues/16)

Translates COMX input to cygwin in port prompt function.

