### PR TITLE
Consolidate flags

### DIFF
--- a/inc/emulator.h
+++ b/inc/emulator.h
@@ -42,7 +42,7 @@ extern "C" {
 /*------------------------------------------------------------------------------
  Macros  
 ------------------------------------------------------------------------------*/
-typedef uint8_t EMULATOR_FLAGS_TYPE; 
+typedef uint32_t EMULATOR_FLAGS_TYPE; 
 
 #define IGNITE_FLAG_BIT (1 << 0)
 #define IRQ_ENABLED_FLAG_BIT (1 << 1)

--- a/inc/emulator.h
+++ b/inc/emulator.h
@@ -42,7 +42,7 @@ extern "C" {
 /*------------------------------------------------------------------------------
  Macros  
 ------------------------------------------------------------------------------*/
-#define EMULATOR_FLAGS_TYPE uint8_t
+typedef uint8_t EMULATOR_FLAGS_TYPE; 
 
 #define IGNITE_FLAG_BIT (1 << 0)
 #define IRQ_ENABLED_FLAG_BIT (1 << 1)

--- a/inc/emulator.h
+++ b/inc/emulator.h
@@ -42,7 +42,11 @@ extern "C" {
 /*------------------------------------------------------------------------------
  Macros  
 ------------------------------------------------------------------------------*/
+#define EMULATOR_FLAGS_TYPE uint8_t
 
+#define IGNITE_FLAG_BIT (1 << 0)
+#define IRQ_ENABLED_FLAG_BIT (1 << 1)
+#define GUI_ENABLED_FLAG_BIT (1 << 2)
 
 /*------------------------------------------------------------------------------
  Typedefs
@@ -111,11 +115,6 @@ void set_gui_status_led
     const float b
     );
 
-void set_ignite_flag
-    (
-    bool status
-    );
-
 void emulator_gui_init
     (
     void
@@ -162,6 +161,23 @@ void* emulator_gps_it_listener
     (
     void* arg
     );
+
+void emulator_flags_set_bits
+    (
+    EMULATOR_FLAGS_TYPE flags
+    );
+
+void emulator_flags_unset_bits
+    (
+    EMULATOR_FLAGS_TYPE flags
+    );
+
+bool emulator_flags_check_bits
+    (
+    EMULATOR_FLAGS_TYPE flags
+    );
+
+
 
 #ifdef __cplusplus
 }

--- a/src/emulator.c
+++ b/src/emulator.c
@@ -54,10 +54,6 @@ const char DEVICE_ID[] = "SW_EMULATOR";
  Globals                                                       
 ------------------------------------------------------------------------------*/
 
-extern volatile bool ignite_flag;
-volatile bool irq_enabled = true;
-volatile bool gui_enable = true;
-
 /*------------------------------------------------------------------------------
  Static Variables
 ------------------------------------------------------------------------------*/
@@ -65,6 +61,8 @@ volatile bool gui_enable = true;
 static pthread_t firmware_thread;
 static pthread_t it_thread;
 static pthread_t gps_thread;
+
+static EMULATOR_FLAGS_TYPE emulator_flags = IRQ_ENABLED_FLAG_BIT | GUI_ENABLED_FLAG_BIT;
 
 /*------------------------------------------------------------------------------
  Static Functions
@@ -121,7 +119,7 @@ while (1)
         case 0:
             if ( option_index == 0 )
                 {
-                gui_enable = false;
+                emulator_flags_unset_bits(GUI_ENABLED_FLAG_BIT);
                 }
             else if ( option_index == 1 )
                 {
@@ -168,8 +166,8 @@ uint32_t HAL_GetUIDw2(void) {
 }
 
 /* checked by emulator_uart and emulator_i2c before mocking ISRs */
-void HAL_NVIC_DisableIRQ(IRQn_Type IRQn) {irq_enabled = false;}
-void HAL_NVIC_EnableIRQ(IRQn_Type IRQn) {irq_enabled = true;}
+void HAL_NVIC_DisableIRQ(IRQn_Type IRQn) {emulator_flags_unset_bits(IRQ_ENABLED_FLAG_BIT);}
+void HAL_NVIC_EnableIRQ(IRQn_Type IRQn) {emulator_flags_set_bits(IRQ_ENABLED_FLAG_BIT);}
 
 /*------------------------------------------------------------------------------
  Procedures                                                     
@@ -240,7 +238,9 @@ else
  Initialize GUI
 ------------------------------------------------------------------------------*/
 
-if ( gui_enable ) 
+printf( "%d", emulator_flags_check_bits(GUI_ENABLED_FLAG_BIT) );
+
+if ( emulator_flags_check_bits(GUI_ENABLED_FLAG_BIT) ) 
     {
 
     /*------------------------------------------------------------------------------
@@ -273,7 +273,7 @@ void emulator_exit
 {
 
 printf("Emulator terminating with exit code %d", exitCode);
-if ( gui_enable ) 
+if ( emulator_flags_check_bits(GUI_ENABLED_FLAG_BIT) )
     {
     emulator_gui_teardown();
     }
@@ -282,5 +282,76 @@ if ( gui_enable )
 exit(exitCode);
 
 }
+
+/*
+ * Bitwise ORs the passed flags with the flag bitfield
+ */
+void emulator_flags_set_bits
+    (
+    EMULATOR_FLAGS_TYPE flags
+    )
+{
+emulator_flags |= flags;
+
+}
+
+/*
+ * Bitwise ANDs the negation of the passed flags to set the passed flag bits to zero
+ */
+void emulator_flags_unset_bits
+    (
+    EMULATOR_FLAGS_TYPE flags
+    )
+{
+emulator_flags &= ~flags;
+
+}
+
+static bool emulator_flags_check_bits_iter
+    (
+     EMULATOR_FLAGS_TYPE flags,
+     int bit_index,
+     EMULATOR_FLAGS_TYPE runner
+    )
+{
+EMULATOR_FLAGS_TYPE mask = (flags & (~flags | 1 << bit_index));
+bool thisFlag = emulator_flags & mask;
+if ( (emulator_flags & mask) == 0 && (flags & mask) == 1)
+    {
+    return false;
+
+    }
+
+runner |= (thisFlag << bit_index);
+
+if (bit_index != 0)
+    {
+    return emulator_flags_check_bits_iter(flags, --bit_index, runner);
+
+    } 
+else
+    {
+    return (flags & runner) == flags;
+
+    }
+}
+
+/*
+ * Returns TRUE only if all passed flags are enabled 
+ */
+bool emulator_flags_check_bits
+    (
+    EMULATOR_FLAGS_TYPE flags
+    )
+{
+
+if ( (emulator_flags & flags) == 0 )
+    {
+        return false;
+    }
+
+return emulator_flags_check_bits_iter(flags, (sizeof(EMULATOR_FLAGS_TYPE) * 8) - 1, 0);
+}
+
 
 

--- a/src/emulator.c
+++ b/src/emulator.c
@@ -244,8 +244,6 @@ else
  Initialize GUI
 ------------------------------------------------------------------------------*/
 
-printf( "%d", emulator_flags_check_bits(GUI_ENABLED_FLAG_BIT) );
-
 if ( emulator_flags_check_bits(GUI_ENABLED_FLAG_BIT) ) 
     {
 

--- a/src/emulator_gpio.c
+++ b/src/emulator_gpio.c
@@ -35,7 +35,6 @@
 /*------------------------------------------------------------------------------
  Globals                                                       
 ------------------------------------------------------------------------------*/
-volatile bool ignite_flag = false;
 extern int serial_port; /* DO NOT MODIFY IN THIS FILE */
 
 /*------------------------------------------------------------------------------
@@ -105,7 +104,7 @@ GPIO_PinState HAL_GPIO_ReadPin(const GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin) {
     if ( ( GPIOx == SWITCH_GPIO_PORT )
       && ( GPIO_Pin == SWITCH_PIN) )
         {
-        return (GPIO_PinState)ignite_flag;
+        return (GPIO_PinState)emulator_flags_check_bits(IGNITE_FLAG_BIT);
         }
     if ( ( GPIOx == USB_DETECT_GPIO_PORT )
       && ( GPIO_Pin ==  USB_DETECT_PIN) )
@@ -119,12 +118,3 @@ GPIO_PinState HAL_GPIO_ReadPin(const GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin) {
 /*------------------------------------------------------------------------------
  Procedures                                                     
 ------------------------------------------------------------------------------*/
-
-void set_ignite_flag
-    (
-    bool status
-    ) 
-{
-ignite_flag = status;
-}
-

--- a/src/emulator_gui.c
+++ b/src/emulator_gui.c
@@ -455,7 +455,7 @@ static void glfwKeyCallback
     if ( key == GLFW_KEY_R && action == GLFW_PRESS && mods & GLFW_MOD_CONTROL ) 
     {
     printf("IGNITE SET\n");
-    set_ignite_flag(true);
+    emulator_flags_set_bits(IGNITE_FLAG_BIT);
     }
 
 } /* glfwKeyCallback */

--- a/src/emulator_i2c.c
+++ b/src/emulator_i2c.c
@@ -42,7 +42,6 @@
 /*------------------------------------------------------------------------------
  Globals                                                       
 ------------------------------------------------------------------------------*/
-extern volatile bool irq_enabled;
 
 volatile bool imu_data_it_flag = false;
 volatile bool baro_data_it_flag = false;
@@ -183,7 +182,7 @@ while ( listening )
     pthread_mutex_lock(&it_mutex); /* lock to safely access shared flags */
     bool call_imu = false, call_baro = false, call_mag = false;
         
-        if (irq_enabled) {
+        if ( emulator_flags_check_bits(IRQ_ENABLED_FLAG_BIT) ) {
             if (imu_data_it_flag) {
                 imu_data_it_flag = false;
                 call_imu = true;

--- a/src/emulator_uart.c
+++ b/src/emulator_uart.c
@@ -48,7 +48,6 @@
 /*------------------------------------------------------------------------------
  Globals                                                       
 ------------------------------------------------------------------------------*/
-extern volatile bool      irq_enabled;
 extern uint8_t            gps_mesg_byte;
 extern uint8_t            rx_buffer[GPSBUFSIZE];
 extern GPS_DATA           gps_data;
@@ -363,7 +362,7 @@ while (recieve_gps)
     req.tv_nsec = GPS_SIM_DELAY * 1000000L; /* milliseconds to nanoseconds */
     nanosleep(&req, NULL);
 
-    if (irq_enabled) 
+    if ( emulator_flags_check_bits(IRQ_ENABLED_FLAG_BIT) ) 
         {
         pthread_mutex_lock(&uart_it_mutex); /* lock to safely access shared flags */
         gps_data_it_flag = false;


### PR DESCRIPTION
Changes emulator flags from global bools to a single bitfield with getters/setters. Idea was to reduce amount of externs as number of flags grows.

@ETSells Would have messed with your fast arm changes, but I already merged them.