### PR TITLE
Route emulator logging through a unified logger

### DIFF
--- a/inc/emulator.h
+++ b/inc/emulator.h
@@ -40,11 +40,6 @@ extern "C" {
 
 
 /*------------------------------------------------------------------------------
- Macros  
-------------------------------------------------------------------------------*/
-
-
-/*------------------------------------------------------------------------------
  Typedefs
 ------------------------------------------------------------------------------*/
 
@@ -84,6 +79,13 @@ void emulator_buzzer_beep_request(uint32_t duration);
 void emulator_setup_error
     (
     void
+    );
+
+void emulator_debug_log
+    (
+    const char* msg,
+    size_t msg_len,
+    const char* from_subsystem /* name of subsystem that logged the message */
     );
 
 /* emulator_i2c.c */
@@ -163,6 +165,11 @@ void* emulator_gps_it_listener
     void* arg
     );
 
+/*------------------------------------------------------------------------------
+ Alias Macros                                             
+------------------------------------------------------------------------------*/
+#define emulator_log( msg, subsystem ) \
+    emulator_debug_log( msg, sizeof( msg ), subsystem );
 #ifdef __cplusplus
 }
 #endif

--- a/inc/emulator.h
+++ b/inc/emulator.h
@@ -55,6 +55,7 @@ extern "C" {
 #define EMULATOR_SUBSYSTEM_SERIAL "SERIAL"
 #define EMULATOR_SUBSYSTEM_GPS "GPS"
 #define EMULATOR_SUBSYSTEM_FIRMWARE "FW-DBG"
+#define EMULATOR_SUBSYSTEM_ERROR "ERROR"
 
 /*------------------------------------------------------------------------------
  Typedefs

--- a/inc/emulator.h
+++ b/inc/emulator.h
@@ -114,6 +114,7 @@ void emulator_debug_log
     const char* from_subsystem /* name of subsystem that logged the message */
     );
 
+/* emulator_error.c */
 void emulator_debug_logf
     (
     const char* msg,

--- a/inc/emulator.h
+++ b/inc/emulator.h
@@ -47,6 +47,15 @@ extern "C" {
 #define GUI_ENABLED_FLAG_BIT (1 << 2)
 #define IGNITE_FAST_ARM_FLAG_BIT (1 << 3)
 
+#define EMULATOR_SUBSYSTEM_INIT "EM-INIT"
+#define EMULATOR_SUBSYSTEM_GUI_INIT "GUI-INIT"
+#define EMULATOR_SUBSYSTEM_GUI_INFO "INFO"
+#define EMULATOR_SUBSYSTEM_I2C_THREAD "I2C-THREAD"
+#define EMULATOR_SUBSYSTEM_FLASH "FLASH"
+#define EMULATOR_SUBSYSTEM_BUZZER "BUZZER"
+#define EMULATOR_SUBSYSTEM_SERIAL "SERIAL"
+#define EMULATOR_SUBSYSTEM_GPS "GPS"
+
 /*------------------------------------------------------------------------------
  Typedefs
 ------------------------------------------------------------------------------*/
@@ -89,6 +98,7 @@ void emulator_setup_error
     void
     );
 
+/* emulator_error.c */
 void emulator_debug_log
     (
     const char* msg,

--- a/inc/emulator.h
+++ b/inc/emulator.h
@@ -60,7 +60,7 @@ extern "C" {
  Typedefs
 ------------------------------------------------------------------------------*/
 typedef uint32_t EMULATOR_FLAGS_TYPE; 
-/* forward decl */
+/* forward decl from FW timer.h */
 typedef struct _SYSTEM_TIME SYSTEM_TIME;
 
 /*------------------------------------------------------------------------------

--- a/inc/emulator.h
+++ b/inc/emulator.h
@@ -37,7 +37,7 @@ extern "C" {
 /*------------------------------------------------------------------------------
  Project Includes  
 ------------------------------------------------------------------------------*/
-
+#include "timer.h"
 
 /*------------------------------------------------------------------------------
  Macros  
@@ -55,6 +55,7 @@ extern "C" {
 #define EMULATOR_SUBSYSTEM_BUZZER "BUZZER"
 #define EMULATOR_SUBSYSTEM_SERIAL "SERIAL"
 #define EMULATOR_SUBSYSTEM_GPS "GPS"
+#define EMULATOR_SUBSYSTEM_FIRMWARE "FW-DBG"
 
 /*------------------------------------------------------------------------------
  Typedefs
@@ -86,6 +87,12 @@ void emulator_exit
 
 /* emulator_timer.c */
 void emulator_start_timers
+    (
+    void
+    );
+
+/* emulator_timer.c */
+SYSTEM_TIME get_system_time
     (
     void
     );

--- a/inc/emulator.h
+++ b/inc/emulator.h
@@ -37,7 +37,6 @@ extern "C" {
 /*------------------------------------------------------------------------------
  Project Includes  
 ------------------------------------------------------------------------------*/
-#include "timer.h"
 
 /*------------------------------------------------------------------------------
  Macros  
@@ -49,7 +48,7 @@ extern "C" {
 
 #define EMULATOR_SUBSYSTEM_INIT "EM-INIT"
 #define EMULATOR_SUBSYSTEM_GUI_INIT "GUI-INIT"
-#define EMULATOR_SUBSYSTEM_GUI_INFO "INFO"
+#define EMULATOR_SUBSYSTEM_GUI_INFO "EM-INFO"
 #define EMULATOR_SUBSYSTEM_I2C_THREAD "I2C-THREAD"
 #define EMULATOR_SUBSYSTEM_FLASH "FLASH"
 #define EMULATOR_SUBSYSTEM_BUZZER "BUZZER"
@@ -61,6 +60,8 @@ extern "C" {
  Typedefs
 ------------------------------------------------------------------------------*/
 typedef uint32_t EMULATOR_FLAGS_TYPE; 
+/* forward decl */
+typedef struct _SYSTEM_TIME SYSTEM_TIME;
 
 /*------------------------------------------------------------------------------
  Global Variables                                             
@@ -111,6 +112,13 @@ void emulator_debug_log
     const char* msg,
     size_t msg_len,
     const char* from_subsystem /* name of subsystem that logged the message */
+    );
+
+void emulator_debug_logf
+    (
+    const char* msg,
+    const char* from_subsystem, /* name of subsystem that logged the message */
+    ...
     );
 
 /* emulator_i2c.c */
@@ -203,8 +211,11 @@ bool emulator_flags_check_bits
 /*------------------------------------------------------------------------------
  Alias Macros                                             
 ------------------------------------------------------------------------------*/
-#define emulator_log( msg, subsystem ) \
-    emulator_debug_log( msg, sizeof( msg ), subsystem );
+#define emulator_log( msg, subsystem )\
+        emulator_debug_log( msg, sizeof( msg ), subsystem )
+
+#define emulator_logf(msg, subsystem, ...)\
+        emulator_debug_logf(msg, subsystem, __VA_ARGS__)
 
 #ifdef __cplusplus
 }

--- a/src/emulator.c
+++ b/src/emulator.c
@@ -212,16 +212,16 @@ emulator_flash_init();
 ------------------------------------------------------------------------------*/
 srand(time(NULL));
 
-printf("Emulator Init: Opening I2c interrupt listener.\n");
+emulator_log("Opening I2c interrupt listener.", "EM-INIT");
 pthread_create( &it_thread, NULL, emulator_i2c_it_listener, NULL );
 
-printf("Emulator Init: Opening GPS interrupt listener.\n");
+emulator_log("Opening GPS interrupt listener.", "EM-INIT");
 pthread_create( &gps_thread, NULL, emulator_gps_it_listener, NULL );
 
 /*------------------------------------------------------------------------------
  Register Default Error Callback                                                   
 ------------------------------------------------------------------------------*/
-printf("Emulator Init: Registering default error handler.\n");
+emulator_log("Registering default error handler.", "EM-INIT");
 emulator_setup_error();
 
 /*------------------------------------------------------------------------------
@@ -229,12 +229,11 @@ emulator_setup_error();
 ------------------------------------------------------------------------------*/
 if ( emulator_prompt_and_open_serial_port() )
     {
-    printf("Emulator Init: Serial connection OK.\n");
+    emulator_log("Serial connection OK.", "EM-INIT");
     }
 else
     {
-    printf("Emulator Init: Serial connection failed. Continuing without.\n");
-    
+    emulator_log("Serial connection failed -- continuing without.", "EM-INIT");
     }
 /*------------------------------------------------------------------------------
  Initialize GUI
@@ -242,11 +241,10 @@ else
 
 if ( gui_enable ) 
     {
-
     /*------------------------------------------------------------------------------
      Once setup is complete, run the firmware                                                    
     ------------------------------------------------------------------------------*/
-    printf("Emulator Init: Starting firmware.\n");
+    emulator_log("Starting firmware.", "EM-INIT");
 
     /* Ugly cast to correct function type (might be the worst cast I've ever seen) */
     /* Shouldn't happen in normal execution, but if main_fut returns, likely UB */
@@ -271,8 +269,10 @@ void emulator_exit
     int exitCode
     )
 {
-
-printf("Emulator terminating with exit code %d", exitCode);
+char dbg_msg[128];
+size_t true_size = 0;
+true_size = snprintf(dbg_msg, 128, "Emulator terminating with exit code %d.", exitCode);
+emulator_debug_log(dbg_msg, true_size, "EM-EXIT");
 if ( gui_enable ) 
     {
     emulator_gui_teardown();

--- a/src/emulator.c
+++ b/src/emulator.c
@@ -216,16 +216,16 @@ emulator_flash_init();
 ------------------------------------------------------------------------------*/
 srand(time(NULL));
 
-emulator_log("Opening I2c interrupt listener.", "EM-INIT");
+emulator_log("Opening I2c interrupt listener.", EMULATOR_SUBSYSTEM_INIT);
 pthread_create( &it_thread, NULL, emulator_i2c_it_listener, NULL );
 
-emulator_log("Opening GPS interrupt listener.", "EM-INIT");
+emulator_log("Opening GPS interrupt listener.", EMULATOR_SUBSYSTEM_INIT);
 pthread_create( &gps_thread, NULL, emulator_gps_it_listener, NULL );
 
 /*------------------------------------------------------------------------------
  Register Default Error Callback                                                   
 ------------------------------------------------------------------------------*/
-emulator_log("Registering default error handler.", "EM-INIT");
+emulator_log("Registering default error handler.", EMULATOR_SUBSYSTEM_INIT);
 emulator_setup_error();
 
 /*------------------------------------------------------------------------------
@@ -233,11 +233,11 @@ emulator_setup_error();
 ------------------------------------------------------------------------------*/
 if ( emulator_prompt_and_open_serial_port() )
     {
-    emulator_log("Serial connection OK.", "EM-INIT");
+    emulator_log("Serial connection OK.", EMULATOR_SUBSYSTEM_INIT);
     }
 else
     {
-    emulator_log("Serial connection failed -- continuing without.", "EM-INIT");
+    emulator_log("Serial connection failed -- continuing without.", EMULATOR_SUBSYSTEM_INIT);
     }
 /*------------------------------------------------------------------------------
  Initialize GUI
@@ -248,7 +248,7 @@ if ( emulator_flags_check_bits(GUI_ENABLED_FLAG_BIT) )
     /*------------------------------------------------------------------------------
      Once setup is complete, run the firmware                                                    
     ------------------------------------------------------------------------------*/
-    emulator_log("Starting firmware.", "EM-INIT");
+    emulator_log("Starting firmware.", EMULATOR_SUBSYSTEM_INIT);
 
     /* Ugly cast to correct function type (might be the worst cast I've ever seen) */
     /* Shouldn't happen in normal execution, but if main_fut returns, likely UB */

--- a/src/emulator.c
+++ b/src/emulator.c
@@ -273,10 +273,7 @@ void emulator_exit
     int exitCode
     )
 {
-char dbg_msg[128];
-size_t true_size = 0;
-true_size = snprintf(dbg_msg, 128, "Emulator terminating with exit code %d.", exitCode);
-emulator_debug_log(dbg_msg, true_size, "EM-EXIT");
+emulator_logf("Emulator terminating with exit code %d.", EMULATOR_SUBSYSTEM_GUI_INFO, exitCode);
 if ( emulator_flags_check_bits(GUI_ENABLED_FLAG_BIT) )
     {
     emulator_gui_teardown();

--- a/src/emulator_error.c
+++ b/src/emulator_error.c
@@ -29,23 +29,15 @@
 #include <stdio.h>
 #include <stddef.h>
 
-#if defined(__GLIBC__)
-#include <execinfo.h>
-#elif defined( _WIN32 ) || defined( __CYGWIN__ )
-#include <windows.h>
-#include <DbgHelp.h>
-#else
-#warning "Your platform does not support backtraces. Please contribute this feature or report your toolchain information."
-#endif
-
 #include "emulator.h"
-
 #include "error_sdr.h"
+#include "debug_sdr.h"
 
 /*------------------------------------------------------------------------------
  Constants                                                       
 ------------------------------------------------------------------------------*/
 #define MAX_FRAMES 128
+#define LOGGING_DIRECTORY "../../emulator/logs/"
 
 /*------------------------------------------------------------------------------
  Globals                                                       
@@ -60,14 +52,55 @@ static void emulator_error_handler
     ERROR_CODE error_code
     );
 
-static void print_stack_trace
-    (
-    void
-    );
-
 /*------------------------------------------------------------------------------
  Procedures                                                     
 ------------------------------------------------------------------------------*/
+
+/*******************************************************************************
+*                                                                              *
+* PROCEDURE:                                                                   * 
+* 		emulator_debug_log                                                     *
+*                                                                              *
+* DESCRIPTION:                                                                 * 
+*       Log to the console.                                                    *
+*                                                                              *
+*******************************************************************************/
+void emulator_debug_log
+    (
+    const char* msg,
+    size_t msg_len,
+    const char* from_subsystem /* name of subsystem that logged the message */
+    )
+{
+char log_msg[DEBUG_MSG_MAX_LEN + 32] = "[";
+size_t new_len = 1;
+if( from_subsystem != NULL )
+    {
+    new_len += strlcpy(log_msg + 1, from_subsystem, 29);
+    }
+else
+    {
+    new_len += strlcpy(log_msg + 1, "EMULATOR", 29);
+    }
+log_msg[new_len] = ']';
+log_msg[new_len + 1] = ' ';
+new_len += 2;
+
+// Override newline logic to make sure we have it here
+if( msg_len > 0 && msg[msg_len - 1] == '\n' )
+    {
+    msg_len--;
+    }
+memcpy(log_msg + new_len, msg, msg_len);
+new_len += msg_len;
+log_msg[new_len] = '\n';
+new_len++;
+fwrite(log_msg, 1, (int)new_len, stdout);
+fflush(stdout); /* put and flush immediately */
+
+// ETS TODO: Log to subsystem file
+
+}
 
 /*******************************************************************************
 *                                                                              *
@@ -85,6 +118,8 @@ void emulator_setup_error
 {
 default_error_handler = (ERROR_CALLBACK){ 0, emulator_error_handler };
 
+/* clear last logs */
+// ETS TODO
 } /* emulator_setup_error */
 
 
@@ -94,7 +129,7 @@ default_error_handler = (ERROR_CALLBACK){ 0, emulator_error_handler };
 * 		emulator_error_handler                                                 *
 *                                                                              *
 * DESCRIPTION:                                                                 * 
-*       Start the GUI socket.                                                  *
+*       Handle an error in the emulator.                                       *
 *                                                                              *
 *******************************************************************************/
 static void emulator_error_handler
@@ -102,83 +137,11 @@ static void emulator_error_handler
     ERROR_CODE error_code
     )
 {
-printf( "\nEmulator: A terminal error has been reached.\n" );
-printf( "Emulator: FW-reported error code - %d.\n", error_code );
-print_stack_trace();
-printf( "\nEmulator: The emulator will now exit.\n");
+char error_msg[64];
+size_t error_len = 0;
+emulator_log("The emulator has encountered a terminal error and will now exit.\n", "ERROR-HANDLER");
+error_len = snprintf(error_msg, 64, "Provided error code: %d\n", error_code);
+emulator_debug_log(error_msg, error_len, "ERROR-HANDLER" );
 exit(0);
 
 } /* emulator_error_handler */
-
-
-/*******************************************************************************
-*                                                                              *
-* PROCEDURE:                                                                   * 
-* 		print_stack_trace                                                      *
-*                                                                              *
-* DESCRIPTION:                                                                 * 
-*       Print the current call stack to the console.                           *
-*                                                                              *
-*******************************************************************************/
-static void print_stack_trace
-    (
-    void
-    ) 
-{
-#if defined(__GLIBC__)
-void* callstack[MAX_FRAMES];
-int frames, i;
-char** strs;
-
-frames = backtrace(callstack, MAX_FRAMES);
-strs = backtrace_symbols(callstack, frames);
-
-if (strs == NULL) {
-    perror("Emulator: A backtrace could not be completed.");
-    exit(EXIT_FAILURE);
-}
-
-printf("Emulator: Stack trace (max %d frames):\n", MAX_FRAMES);
-for (i = 0; i < frames; ++i) {
-    printf("%s\n", strs[i]);
-}
-
-free(strs);
-#elif defined( _WIN32 ) || defined( __CYGWIN__ )
-/**
- * The following code is exempt from software licensing on this project.
- * This is not original code and Sun Devil Rocketry does not claim ownership.
- * Source:
- * 
- * https://stackoverflow.com/questions/5693192/win32-backtrace-from-c-code
- */
-unsigned int   i;
-void         * stack[ 100 ];
-unsigned short frames;
-SYMBOL_INFO  * symbol;
-HANDLE         process;
-
-process = GetCurrentProcess();
-
-SymInitialize( process, NULL, TRUE );
-
-frames               = CaptureStackBackTrace( 0, 100, stack, NULL );
-symbol               = ( SYMBOL_INFO * )calloc( sizeof( SYMBOL_INFO ) + 256 * sizeof( char ), 1 );
-symbol->MaxNameLen   = 255;
-symbol->SizeOfStruct = sizeof( SYMBOL_INFO );
-
-printf( "Emulator: Stack trace:\n" );
-for( i = 0; i < frames; i++ )
-    {
-    SymFromAddr( process, ( DWORD64 )( stack[ i ] ), 0, symbol );
-
-    printf( "%i: %s - 0x%0llX\n", frames - i - 1, symbol->Name, symbol->Address );
-    }
-
-free( symbol );
-
-printf( "Emulator: The stack trace for windows builds is very imperfect. Sorry!\n" );
-#else
-printf("Emulator: Your platform does not support backtraces for errors.\n");
-#endif
-} /* print_stack_trace */

--- a/src/emulator_error.c
+++ b/src/emulator_error.c
@@ -77,21 +77,19 @@ void emulator_debug_log
 /* We have RAM privileges so we can ignore the firmware's feeble 'max message size' */
 (void)msg_len;
 
-const char* fmt_string = "[%02u:%02u:%02u:%03u] [%s] %s\n";
+const char* fmt_string = "[%02u:%02u:%02u.%03u] [%s] %s\n";
 
 if ( from_subsystem == NULL )
     {
     from_subsystem = "EMULATOR";
     }
-// TODO: Make debug_writer is main.c use the firmware subsystem macro
-// I'm not doing that rn because I dont want to make a second pr :P
 else if ( strcmp(EMULATOR_SUBSYSTEM_FIRMWARE, from_subsystem) == 0 )
     {
-    // Skip the timestamp in the preamble
-    // This will have to change if the preamble format changes
+    /* The firmware computes its own timestamp, but we can override this since
+    the async circular buffer goes unused in the emulator case. */
     size_t offset = sizeof("[XX:XX:XX.XXX");
     msg += offset;
-    fmt_string = "[%02u:%02u:%02u:%03u] [%s] [%s\n";
+    fmt_string = "[%02u:%02u:%02u.%03u] [%s] [%s"; // skip trailing newline -- handled in dbg module
     }
 
 SYSTEM_TIME curr_time = get_system_time();
@@ -132,13 +130,27 @@ snprintf
     msg
     );
 
-// ETS TODO: Log to subsystem file
+// At some point, we may want to consider categorizing logs based on subsystem
+// For now, just write and flush immediately.
 fwrite(msg_buf, sizeof(char), fmt_size, stdout);
 fflush(stdout); /* put and flush immediately */
 
 free(msg_buf);
-}
 
+} /* emulator_debug_log */
+
+
+/*******************************************************************************
+*                                                                              *
+* PROCEDURE:                                                                   * 
+* 		emulator_debug_logf                                                    *
+*                                                                              *
+* DESCRIPTION:                                                                 * 
+*       Log to the console using a format string. Checks variadic arguments at *
+*       compile time. Thanks, GCC!                                             *
+*                                                                              *
+*******************************************************************************/
+__attribute__((format(printf, 1, 3)))
 void emulator_debug_logf
     (
     const char* msg,
@@ -167,7 +179,8 @@ free(new_msg);
 
 va_end(vargs);
 
-}
+} /* emulator_debug_logf */
+
 
 /*******************************************************************************
 *                                                                              *
@@ -186,7 +199,7 @@ void emulator_setup_error
 default_error_handler = (ERROR_CALLBACK){ 0, emulator_error_handler };
 
 /* clear last logs */
-// ETS TODO
+// TODO
 } /* emulator_setup_error */
 
 

--- a/src/emulator_error.c
+++ b/src/emulator_error.c
@@ -72,34 +72,68 @@ void emulator_debug_log
     const char* from_subsystem /* name of subsystem that logged the message */
     )
 {
-char log_msg[DEBUG_MSG_MAX_LEN + 32] = "[";
-size_t new_len = 1;
-if( from_subsystem != NULL )
-    {
-    new_len += strlcpy(log_msg + 1, from_subsystem, 29);
-    }
-else
-    {
-    new_len += strlcpy(log_msg + 1, "EMULATOR", 29);
-    }
-log_msg[new_len] = ']';
-log_msg[new_len + 1] = ' ';
-new_len += 2;
+/* We have RAM privlieges so we can ignore the firmware's feeble 'max message size' */
+(void)msg_len;
 
-// Override newline logic to make sure we have it here
-if( msg_len > 0 && msg[msg_len - 1] == '\n' )
+char* fmt_string = "[%02u:%02u:%02u:%03u] [%s] %s\n";
+
+if ( from_subsystem == NULL )
     {
-    msg_len--;
+    from_subsystem = "EMULATOR";
     }
-memcpy(log_msg + new_len, msg, msg_len);
-new_len += msg_len;
-log_msg[new_len] = '\n';
-new_len++;
-fwrite(log_msg, 1, (int)new_len, stdout);
+// TODO: Make debug_writer is main.c use the firmware subsystem macro
+// I'm not doing that rn because I dont want to make a second pr :P
+else if ( strcmp(EMULATOR_SUBSYSTEM_FIRMWARE, from_subsystem) == 0 )
+    {
+        // Skip the timestamp in the preamble
+        // This will have to change if the preamble format changes
+        size_t offset = sizeof("[XX:XX:XX.XXX");
+        msg += offset;
+        fmt_string = "[%02u:%02u:%02u:%03u] [%s] [%s\n";
+    }
+
+SYSTEM_TIME curr_time = get_system_time();
+
+/* +1 for null terminator */
+size_t fmt_size = snprintf
+                    (
+                    NULL, 
+                    0, 
+                    fmt_string, 
+                    curr_time.hours,
+                    curr_time.mins,
+                    curr_time.secs,
+                    curr_time.millis,
+                    from_subsystem,
+                    msg
+                    ) + 1;
+
+char* msg_buf = malloc(sizeof(char) * fmt_size);
+
+if ( msg_buf == NULL )
+    {
+    const char failed_str[] = "Log message allocation failed\n";
+    fwrite(failed_str, sizeof(char), sizeof(failed_str), stdout);
+    return;
+    }
+
+snprintf
+    (
+    msg_buf, 
+    fmt_size, 
+    fmt_string, 
+    curr_time.hours,
+    curr_time.mins,
+    curr_time.secs,
+    curr_time.millis,
+    from_subsystem,
+    msg
+    );
+
+fwrite(msg_buf, sizeof(char), fmt_size, stdout);
 fflush(stdout); /* put and flush immediately */
 
-// ETS TODO: Log to subsystem file
-
+free(msg_buf);
 }
 
 /*******************************************************************************

--- a/src/emulator_error.c
+++ b/src/emulator_error.c
@@ -74,7 +74,7 @@ void emulator_debug_log
     const char* from_subsystem /* name of subsystem that logged the message */
     )
 {
-/* We have RAM privlieges so we can ignore the firmware's feeble 'max message size' */
+/* We have RAM privileges so we can ignore the firmware's feeble 'max message size' */
 (void)msg_len;
 
 const char* fmt_string = "[%02u:%02u:%02u:%03u] [%s] %s\n";

--- a/src/emulator_error.c
+++ b/src/emulator_error.c
@@ -132,6 +132,7 @@ snprintf
     msg
     );
 
+// ETS TODO: Log to subsystem file
 fwrite(msg_buf, sizeof(char), fmt_size, stdout);
 fflush(stdout); /* put and flush immediately */
 

--- a/src/emulator_error.c
+++ b/src/emulator_error.c
@@ -77,7 +77,7 @@ void emulator_debug_log
 /* We have RAM privlieges so we can ignore the firmware's feeble 'max message size' */
 (void)msg_len;
 
-char* fmt_string = "[%02u:%02u:%02u:%03u] [%s] %s\n";
+const char* fmt_string = "[%02u:%02u:%02u:%03u] [%s] %s\n";
 
 if ( from_subsystem == NULL )
     {

--- a/src/emulator_error.c
+++ b/src/emulator_error.c
@@ -28,10 +28,12 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stddef.h>
+#include <stdarg.h>
 
 #include "emulator.h"
 #include "error_sdr.h"
 #include "debug_sdr.h"
+#include "timer.h"
 
 /*------------------------------------------------------------------------------
  Constants                                                       
@@ -136,6 +138,36 @@ fflush(stdout); /* put and flush immediately */
 free(msg_buf);
 }
 
+void emulator_debug_logf
+    (
+    const char* msg,
+    const char* from_subsystem, 
+    ...
+    )
+{
+va_list vargs;
+va_start(vargs, from_subsystem); 
+
+size_t msg_len = vsnprintf(NULL, 0, msg, vargs) + 1; 
+char* new_msg = malloc(sizeof(char) * msg_len); 
+
+if (new_msg == NULL)
+{
+    va_end(vargs);
+    const char failed_str[] = "Log message allocation failed\n";
+    fwrite(failed_str, sizeof(char), sizeof(failed_str), stdout);
+    return;
+}
+
+vsnprintf(new_msg, msg_len, msg, vargs); 
+emulator_debug_log( new_msg, msg_len, from_subsystem ); 
+
+free(new_msg);
+
+va_end(vargs);
+
+}
+
 /*******************************************************************************
 *                                                                              *
 * PROCEDURE:                                                                   * 
@@ -173,7 +205,7 @@ static void emulator_error_handler
 {
 char error_msg[64];
 size_t error_len = 0;
-emulator_log("The emulator has encountered a terminal error and will now exit.\n", "ERROR-HANDLER");
+emulator_log("The emulator has encountered a fatal error and will now exit.\n", "ERROR-HANDLER");
 error_len = snprintf(error_msg, 64, "Provided error code: %d\n", error_code);
 emulator_debug_log(error_msg, error_len, "ERROR-HANDLER" );
 exit(0);

--- a/src/emulator_error.c
+++ b/src/emulator_error.c
@@ -217,11 +217,7 @@ static void emulator_error_handler
     ERROR_CODE error_code
     )
 {
-char error_msg[64];
-size_t error_len = 0;
-emulator_log("The emulator has encountered a fatal error and will now exit.\n", "ERROR-HANDLER");
-error_len = snprintf(error_msg, 64, "Provided error code: %d\n", error_code);
-emulator_debug_log(error_msg, error_len, "ERROR-HANDLER" );
+emulator_logf("The emulator has encountered a fatal error and will now exit. Code: %d\n", EMULATOR_SUBSYSTEM_ERROR, error_code);
 exit(0);
 
 } /* emulator_error_handler */

--- a/src/emulator_error.c
+++ b/src/emulator_error.c
@@ -87,11 +87,11 @@ if ( from_subsystem == NULL )
 // I'm not doing that rn because I dont want to make a second pr :P
 else if ( strcmp(EMULATOR_SUBSYSTEM_FIRMWARE, from_subsystem) == 0 )
     {
-        // Skip the timestamp in the preamble
-        // This will have to change if the preamble format changes
-        size_t offset = sizeof("[XX:XX:XX.XXX");
-        msg += offset;
-        fmt_string = "[%02u:%02u:%02u:%03u] [%s] [%s\n";
+    // Skip the timestamp in the preamble
+    // This will have to change if the preamble format changes
+    size_t offset = sizeof("[XX:XX:XX.XXX");
+    msg += offset;
+    fmt_string = "[%02u:%02u:%02u:%03u] [%s] [%s\n";
     }
 
 SYSTEM_TIME curr_time = get_system_time();
@@ -153,12 +153,12 @@ size_t msg_len = vsnprintf(NULL, 0, msg, vargs) + 1;
 char* new_msg = malloc(sizeof(char) * msg_len); 
 
 if (new_msg == NULL)
-{
+    {
     va_end(vargs);
     const char failed_str[] = "Log message allocation failed\n";
     fwrite(failed_str, sizeof(char), sizeof(failed_str), stdout);
     return;
-}
+    }
 
 vsnprintf(new_msg, msg_len, msg, vargs); 
 emulator_debug_log( new_msg, msg_len, from_subsystem ); 

--- a/src/emulator_gpio.c
+++ b/src/emulator_gpio.c
@@ -61,28 +61,28 @@ void HAL_GPIO_WritePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState Pin
         switch (GPIO_Pin) 
             {
             case STATUS_G_PIN:
-                printf("LED: GREEN\n");
+                //printf("LED: GREEN\n");
                 break;
             case STATUS_R_PIN:
-                printf("LED: RED\n");
+                //printf("LED: RED\n");
                 break;
             case STATUS_B_PIN:
-                printf("LED: BLUE\n");
+                //printf("LED: BLUE\n");
                 break;
             case STATUS_G_PIN | STATUS_R_PIN:
-                printf("LED: YELLOW\n");
+                //printf("LED: YELLOW\n");
                 break;
             case STATUS_G_PIN | STATUS_B_PIN:
-                printf("LED: CYAN\n");
+                //printf("LED: CYAN\n");
                 break;
             case STATUS_R_PIN | STATUS_B_PIN:
-                printf("LED: PURPLE\n");
+                //printf("LED: PURPLE\n");
                 break;
             case STATUS_R_PIN | STATUS_G_PIN | STATUS_B_PIN:
-                printf("LED: WHITE\n");
+                //printf("LED: WHITE\n");
                 break;
             default:
-                printf("-=Indeterminate=-\n");
+                //printf("-=Indeterminate=-\n");
                 break;
             }
         }
@@ -91,7 +91,7 @@ void HAL_GPIO_WritePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState Pin
      && ( GPIO_Pin & ( STATUS_G_PIN | STATUS_R_PIN | STATUS_B_PIN ) )
      && ( PinState == GPIO_PIN_SET ) )
         {
-        printf("LED: RESET\n"); /* TEMP (I lowkey have no idea what this is supposed to do) */
+        //printf("LED: RESET\n"); /* TEMP (I lowkey have no idea what this is supposed to do) */
         set_gui_status_led
             (
             0,

--- a/src/emulator_gui.c
+++ b/src/emulator_gui.c
@@ -165,7 +165,7 @@ void emulator_gui_main
 
 if ( !glfwInit() ) 
     {
-    emulator_log("GLFW Initialization failed.", "GUI-INIT");
+    emulator_log("GLFW Initialization failed.", EMULATOR_SUBSYSTEM_GUI_INIT);
     exit(1);
     }
 
@@ -181,7 +181,7 @@ guiWindow = glfwCreateWindow(640, 480, "SDR HW Emulator", NULL, NULL);
 
 if ( !guiWindow ) 
     {
-    emulator_log("Window Initialization failed.", "GUI-INIT");
+    emulator_log("Window Initialization failed.", EMULATOR_SUBSYSTEM_GUI_INIT);
     glfwTerminate();
     exit(1);
     }
@@ -199,7 +199,7 @@ glDebugMessageCallback(openGLErrorCallback, 0);
 
 /* Load FC obj */
 objData = loadVertexDataFromOBJ(MAKE_RESOURCES_PATH("FC_REV2.obj"));
-emulator_log("FC obj read complete.", "GUI-INIT");
+emulator_log("FC obj read complete.", EMULATOR_SUBSYSTEM_GUI_INIT);
 
 /* Create the VAO for non-LED geometry */
 GLuint defaultVAO;
@@ -366,8 +366,8 @@ glfwShowWindow(guiWindow);
 glfwRequestWindowAttention(guiWindow);
 glfwFocusWindow(guiWindow);
 
-emulator_log("Startup successful. Rise and shine!", "GUI-INIT");
-emulator_log("Press CTRL + R to arm.", "EM-INSTRUCTION");
+emulator_log("Startup successful. Rise and shine!", EMULATOR_SUBSYSTEM_GUI_INIT);
+emulator_log("Press CTRL + R to arm.", EMULATOR_SUBSYSTEM_GUI_INFO);
 
 /* GUI main loop */
 while (!glfwWindowShouldClose(guiWindow)) 
@@ -454,7 +454,7 @@ static void glfwKeyCallback
 
     if ( key == GLFW_KEY_R && action == GLFW_PRESS && mods & GLFW_MOD_CONTROL ) 
     {
-    emulator_log("Ignition input handled", "GUI");
+    emulator_log("Ignition input handled", EMULATOR_SUBSYSTEM_GUI_INFO);
     emulator_flags_set_bits(IGNITE_FLAG_BIT);
     }
 

--- a/src/emulator_gui.c
+++ b/src/emulator_gui.c
@@ -526,7 +526,7 @@ static void GLAPIENTRY openGLErrorCallback
 {
 if ( type == GL_DEBUG_TYPE_ERROR ) 
     {
-    emulator_debug_log(message, strlen(message), "OPENGL");
+    emulator_debug_log(message, length, "OPENGL");
     }
 
 } /* openGLErrorCallback */

--- a/src/emulator_gui.c
+++ b/src/emulator_gui.c
@@ -165,7 +165,7 @@ void emulator_gui_main
 
 if ( !glfwInit() ) 
     {
-    fprintf(stderr, "[GUI]: GLFW Initialization failed");
+    emulator_log("GLFW Initialization failed.", "GUI-INIT");
     exit(1);
     }
 
@@ -181,7 +181,7 @@ guiWindow = glfwCreateWindow(640, 480, "SDR HW Emulator", NULL, NULL);
 
 if ( !guiWindow ) 
     {
-    fprintf(stderr, "[GUI]: Window Initialization failed");
+    emulator_log("Window Initialization failed.", "GUI-INIT");
     glfwTerminate();
     exit(1);
     }
@@ -199,7 +199,7 @@ glDebugMessageCallback(openGLErrorCallback, 0);
 
 /* Load FC obj */
 objData = loadVertexDataFromOBJ(MAKE_RESOURCES_PATH("FC_REV2.obj"));
-printf("FC OBJ READ COMPLETE\n");
+emulator_log("FC obj read complete.", "GUI-INIT");
 
 /* Create the VAO for non-LED geometry */
 GLuint defaultVAO;
@@ -366,9 +366,9 @@ glfwShowWindow(guiWindow);
 glfwRequestWindowAttention(guiWindow);
 glfwFocusWindow(guiWindow);
 
-printf("[GUI STARTUP SUCCESSFUL]: Rise and shine\n");
+emulator_log("Startup successful. Rise and shine!", "GUI-INIT");
+emulator_log("Press CTRL + R to arm.", "EM-INSTRUCTION");
 
-printf("[Emulator]: Press CTRL + R to arm.\n");
 /* GUI main loop */
 while (!glfwWindowShouldClose(guiWindow)) 
     {
@@ -454,8 +454,8 @@ static void glfwKeyCallback
 
     if ( key == GLFW_KEY_R && action == GLFW_PRESS && mods & GLFW_MOD_CONTROL ) 
     {
-    printf("IGNITE SET\n");
     set_ignite_flag(true);
+    emulator_log("Ignition input handled", "GUI");
     }
 
 } /* glfwKeyCallback */
@@ -475,8 +475,7 @@ static void glfw_error_callback
     const char* description
     ) 
 {
-
-fprintf(stderr, "[GLFW ERROR]: %s\n", description);
+emulator_debug_log(description, strlen(description), "GLFW");
 
 } /* error_callback */
 
@@ -527,7 +526,7 @@ static void GLAPIENTRY openGLErrorCallback
 {
 if ( type == GL_DEBUG_TYPE_ERROR ) 
     {
-    fprintf(stderr, "GLERROR: %s\n", message);
+    emulator_debug_log(message, strlen(message), "OPENGL");
     }
 
 } /* openGLErrorCallback */

--- a/src/emulator_i2c.c
+++ b/src/emulator_i2c.c
@@ -161,7 +161,7 @@ void* emulator_i2c_it_listener
     )
 {
 bool listening = true;
-emulator_log("Listener thread opened.", "I2C-THREAD");
+emulator_log("Listener thread opened.", EMULATOR_SUBSYSTEM_I2C_THREAD);
 
 while ( listening )
     {

--- a/src/emulator_i2c.c
+++ b/src/emulator_i2c.c
@@ -162,7 +162,7 @@ void* emulator_i2c_it_listener
     )
 {
 bool listening = true;
-printf("Listener thread opened.\n");
+emulator_log("Listener thread opened.", "I2C-THREAD");
 
 while ( listening )
     {

--- a/src/emulator_init.c
+++ b/src/emulator_init.c
@@ -49,6 +49,7 @@ void GPIO_Init() {}
 void SystemClock_Config() {}
 void PeriphCommonClock_Config() {}
 void LORA_SPI_Init() {}
+void ITM_Init() {}
 HAL_StatusTypeDef HAL_Init() { return HAL_OK; }
 
 /* HTIM inits are in emulator_timer.c */

--- a/src/emulator_spi.c
+++ b/src/emulator_spi.c
@@ -136,16 +136,19 @@ if (flashFileFd == -1 && errno == 2)
     /* Create new flash file if not alreay present */
     /* Do note that the created file has full permissions */
     flashFileFd = open(FLASH_FILENAME, O_CREAT | O_RDWR, S_IRWXO | S_IRWXG | S_IRWXU);
-    printf("Emulator Init: Could not find %s, creating new\n", FLASH_FILENAME);
+    emulator_log("Could not find flash file, creating new.", "EM-INIT");
 }
 
 if ( flashFileFd == -1 ) 
     {
-    fprintf(stderr, "Emulator Init: Flash file failed to open with errno %d", errno);
-    exit(1);
+    char dbg_msg[64];
+    size_t true_size = 0;
+    true_size = snprintf(dbg_msg, 64, "Flash file failed to open with errno %d.", errno);
+    emulator_debug_log(dbg_msg, true_size, "EM-INIT");
+    emulator_exit(1);
     }
 
-printf("Emulator Init: Successfully opened flash file\n");
+emulator_log("Successfully opened flash file.", "EM-INIT");
 
 /* Resize the file to the proper size. */
 /* If the file is the correct format, does nothing. If too long/short, corrects it */
@@ -153,8 +156,11 @@ int resizeStatus = ftruncate(flashFileFd, FLASH_FILESIZE);
 
 if ( resizeStatus == -1)
     {
-    fprintf(stderr, "Emulator Init: Failed to truncate flash file with errno %d\n", errno);
-    exit(1);
+    char dbg_msg[64];
+    size_t true_size = 0;
+    true_size = snprintf(dbg_msg, 64, "Failed to truncate flash file with errno %d.", errno);
+    emulator_debug_log(dbg_msg, true_size, "EM-INIT");
+    emulator_exit(1);
     }
 
 /* Maps the file to memory; when flash_memory is written the file changes simultaneously* */
@@ -170,8 +176,11 @@ if ( !foundFlashFile )
 
 if ( flash_memory == MAP_FAILED ) 
     {
-    fprintf(stderr, "Emulator Init: Flash file mmap failed with errno %d\n", errno);
-    exit(1);
+    char dbg_msg[64];
+    size_t true_size = 0;
+    true_size = snprintf(dbg_msg, 64, "Flash file mmap failed with errno %d.", errno);
+    emulator_debug_log(dbg_msg, true_size, "EM-INIT");
+    emulator_exit(1);
     }
 
 /* File descriptor can be closed without invalidating the mapping, per the man */
@@ -179,11 +188,17 @@ int closeRet = close(flashFileFd);
 
 if ( closeRet == -1 ) 
     {
-    fprintf(stderr, "Emulator Init: Failed to close inital flash file with errno %d\n", errno);
-    exit(1);
+    char dbg_msg[64];
+    size_t true_size = 0;
+    true_size = snprintf(dbg_msg, 64, "Failed to close inital flash file with errno %d.", errno);
+    emulator_debug_log(dbg_msg, true_size, "EM-INIT");
+    emulator_exit(1);
     }
 
-printf("Emulator Init: Successfully mapped %s to memory\n", FLASH_FILENAME);
+char dbg_msg[128];
+size_t true_size = 0;
+true_size = snprintf(dbg_msg, 128, "Successfully mapped %s to memory.", FLASH_FILENAME);
+emulator_debug_log(dbg_msg, true_size, "EM-INIT");
 
 } /* emulator_flash_init */
 
@@ -207,14 +222,15 @@ uint32_t emulator_flash_write
 /* Make sure flash has been initialized */
 if ( flash_memory == NULL ) 
     {
-    printf("Flash Write: Emulator flash is NULL\n");
+    emulator_log("Emulator flash is NULL", "FLASH");
     return FLASH_INIT_FAIL;
     }
 
 /* Check invariants */
 if( address + ( size - 1 ) > FLASH_MAX_ADDR )
     {
-    printf("Flash Write: OOB write at %x with size %d\n", address, size);
+    emulator_log("OOB write attempted. Uncomment the printf in emulator_flash_write to debug.", "FLASH");
+    //printf("Flash Write: OOB write at %x with size %d\n", address, size);
     return FLASH_ADDR_OUT_OF_BOUNDS;
     }
 

--- a/src/emulator_spi.c
+++ b/src/emulator_spi.c
@@ -136,15 +136,12 @@ if (flashFileFd == -1 && errno == 2)
     /* Create new flash file if not alreay present */
     /* Do note that the created file has full permissions */
     flashFileFd = open(FLASH_FILENAME, O_CREAT | O_RDWR, S_IRWXO | S_IRWXG | S_IRWXU);
-    emulator_log("Could not find flash file, creating new.", EMULATOR_SUBSYSTEM_INIT);
+    emulator_logf("Could not find %s, creating new.", EMULATOR_SUBSYSTEM_INIT, FLASH_FILENAME);
 }
 
 if ( flashFileFd == -1 ) 
     {
-    char dbg_msg[64];
-    size_t true_size = 0;
-    true_size = snprintf(dbg_msg, 64, "Flash file failed to open with errno %d.", errno);
-    emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYSTEM_INIT);
+    emulator_logf("Flash file failed to open with errno %d.", EMULATOR_SUBSYSTEM_INIT, errno);
     emulator_exit(1);
     }
 
@@ -156,10 +153,7 @@ int resizeStatus = ftruncate(flashFileFd, FLASH_FILESIZE);
 
 if ( resizeStatus == -1)
     {
-    char dbg_msg[64];
-    size_t true_size = 0;
-    true_size = snprintf(dbg_msg, 64, "Failed to truncate flash file with errno %d.", errno);
-    emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYSTEM_INIT);
+    emulator_logf("Failed to truncate flash file with errno %d", EMULATOR_SUBSYSTEM_INIT, errno);
     emulator_exit(1);
     }
 
@@ -176,10 +170,7 @@ if ( !foundFlashFile )
 
 if ( flash_memory == MAP_FAILED ) 
     {
-    char dbg_msg[64];
-    size_t true_size = 0;
-    true_size = snprintf(dbg_msg, 64, "Flash file mmap failed with errno %d.", errno);
-    emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYSTEM_INIT);
+    emulator_logf("Flash file mmap failed with errno %d.", EMULATOR_SUBSYSTEM_INIT, errno);
     emulator_exit(1);
     }
 
@@ -188,17 +179,11 @@ int closeRet = close(flashFileFd);
 
 if ( closeRet == -1 ) 
     {
-    char dbg_msg[64];
-    size_t true_size = 0;
-    true_size = snprintf(dbg_msg, 64, "Failed to close inital flash file with errno %d.", errno);
-    emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYSTEM_INIT);
+    emulator_logf("Failed to close initial flash file with errno %d.", EMULATOR_SUBSYSTEM_INIT, errno);
     emulator_exit(1);
     }
 
-char dbg_msg[128];
-size_t true_size = 0;
-true_size = snprintf(dbg_msg, 128, "Successfully mapped %s to memory.", FLASH_FILENAME);
-emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYSTEM_INIT);
+emulator_logf("Successfully mapped %s to memory.", EMULATOR_SUBSYSTEM_INIT, FLASH_FILENAME);
 
 } /* emulator_flash_init */
 
@@ -229,8 +214,7 @@ if ( flash_memory == NULL )
 /* Check invariants */
 if( address + ( size - 1 ) > FLASH_MAX_ADDR )
     {
-    emulator_log("OOB write attempted. Uncomment the printf in emulator_flash_write to debug.", EMULATOR_SUBSYSTEM_FLASH);
-    //printf("Flash Write: OOB write at %x with size %d\n", address, size);
+    emulator_logf("OOB write attempted at %x with size %d", EMULATOR_SUBSYSTEM_FLASH, address, size);
     return FLASH_ADDR_OUT_OF_BOUNDS;
     }
 

--- a/src/emulator_spi.c
+++ b/src/emulator_spi.c
@@ -136,7 +136,7 @@ if (flashFileFd == -1 && errno == 2)
     /* Create new flash file if not alreay present */
     /* Do note that the created file has full permissions */
     flashFileFd = open(FLASH_FILENAME, O_CREAT | O_RDWR, S_IRWXO | S_IRWXG | S_IRWXU);
-    emulator_log("Could not find flash file, creating new.", "EM-INIT");
+    emulator_log("Could not find flash file, creating new.", EMULATOR_SUBSYSTEM_INIT);
 }
 
 if ( flashFileFd == -1 ) 
@@ -144,11 +144,11 @@ if ( flashFileFd == -1 )
     char dbg_msg[64];
     size_t true_size = 0;
     true_size = snprintf(dbg_msg, 64, "Flash file failed to open with errno %d.", errno);
-    emulator_debug_log(dbg_msg, true_size, "EM-INIT");
+    emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYSTEM_INIT);
     emulator_exit(1);
     }
 
-emulator_log("Successfully opened flash file.", "EM-INIT");
+emulator_log("Successfully opened flash file.", EMULATOR_SUBSYSTEM_INIT);
 
 /* Resize the file to the proper size. */
 /* If the file is the correct format, does nothing. If too long/short, corrects it */
@@ -159,7 +159,7 @@ if ( resizeStatus == -1)
     char dbg_msg[64];
     size_t true_size = 0;
     true_size = snprintf(dbg_msg, 64, "Failed to truncate flash file with errno %d.", errno);
-    emulator_debug_log(dbg_msg, true_size, "EM-INIT");
+    emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYSTEM_INIT);
     emulator_exit(1);
     }
 
@@ -179,7 +179,7 @@ if ( flash_memory == MAP_FAILED )
     char dbg_msg[64];
     size_t true_size = 0;
     true_size = snprintf(dbg_msg, 64, "Flash file mmap failed with errno %d.", errno);
-    emulator_debug_log(dbg_msg, true_size, "EM-INIT");
+    emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYTEM_INIT);
     emulator_exit(1);
     }
 
@@ -191,14 +191,14 @@ if ( closeRet == -1 )
     char dbg_msg[64];
     size_t true_size = 0;
     true_size = snprintf(dbg_msg, 64, "Failed to close inital flash file with errno %d.", errno);
-    emulator_debug_log(dbg_msg, true_size, "EM-INIT");
+    emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYTEM_INIT);
     emulator_exit(1);
     }
 
 char dbg_msg[128];
 size_t true_size = 0;
 true_size = snprintf(dbg_msg, 128, "Successfully mapped %s to memory.", FLASH_FILENAME);
-emulator_debug_log(dbg_msg, true_size, "EM-INIT");
+emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYTEM_INIT);
 
 } /* emulator_flash_init */
 
@@ -222,14 +222,14 @@ uint32_t emulator_flash_write
 /* Make sure flash has been initialized */
 if ( flash_memory == NULL ) 
     {
-    emulator_log("Emulator flash is NULL", "FLASH");
+    emulator_log("Emulator flash is NULL", EMULATOR_SUBSYSTEM_FLASH);
     return FLASH_INIT_FAIL;
     }
 
 /* Check invariants */
 if( address + ( size - 1 ) > FLASH_MAX_ADDR )
     {
-    emulator_log("OOB write attempted. Uncomment the printf in emulator_flash_write to debug.", "FLASH");
+    emulator_log("OOB write attempted. Uncomment the printf in emulator_flash_write to debug.", EMULATOR_SUBSYSTEM_FLASH);
     //printf("Flash Write: OOB write at %x with size %d\n", address, size);
     return FLASH_ADDR_OUT_OF_BOUNDS;
     }

--- a/src/emulator_spi.c
+++ b/src/emulator_spi.c
@@ -179,7 +179,7 @@ if ( flash_memory == MAP_FAILED )
     char dbg_msg[64];
     size_t true_size = 0;
     true_size = snprintf(dbg_msg, 64, "Flash file mmap failed with errno %d.", errno);
-    emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYTEM_INIT);
+    emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYSTEM_INIT);
     emulator_exit(1);
     }
 
@@ -191,14 +191,14 @@ if ( closeRet == -1 )
     char dbg_msg[64];
     size_t true_size = 0;
     true_size = snprintf(dbg_msg, 64, "Failed to close inital flash file with errno %d.", errno);
-    emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYTEM_INIT);
+    emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYSTEM_INIT);
     emulator_exit(1);
     }
 
 char dbg_msg[128];
 size_t true_size = 0;
 true_size = snprintf(dbg_msg, 128, "Successfully mapped %s to memory.", FLASH_FILENAME);
-emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYTEM_INIT);
+emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYSTEM_INIT);
 
 } /* emulator_flash_init */
 

--- a/src/emulator_timer.c
+++ b/src/emulator_timer.c
@@ -129,6 +129,26 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
     return HAL_OK;
 }
 
+/**
+ * @brief Gets the current time since epoch (startup).
+ */
+SYSTEM_TIME get_system_time
+    (
+    void
+    )
+{
+uint32_t systick = HAL_GetTick();
+SYSTEM_TIME retval;
+
+retval.millis = (uint16_t)(systick % MILLISEC_PER_SEC);
+retval.secs = (uint8_t)((systick / MILLISEC_PER_SEC) % SEC_PER_MIN);
+retval.mins = (uint8_t)((systick / (MILLISEC_PER_SEC * SEC_PER_MIN)) % MIN_PER_HOUR);
+retval.hours = (uint16_t)((systick / (MILLISEC_PER_SEC * SEC_PER_MIN * MIN_PER_HOUR)));
+
+return retval;
+
+} /* get_system_time */
+
 /*------------------------------------------------------------------------------
  Procedures                                                     
 ------------------------------------------------------------------------------*/

--- a/src/emulator_timer.c
+++ b/src/emulator_timer.c
@@ -209,9 +209,10 @@ void emulator_buzzer_beep_request
     uint32_t duration
     )
 {
-char buf[13];
-snprintf( buf, 13, "BUZZ: %05d\n", duration);
-printf("%s\n", buf); /* TEMP until buzzer gets implemented for realz */
+char dbg_msg[128];
+size_t true_size = 0;
+true_size = snprintf(dbg_msg, 128, "Beeping for %d ms.", duration);
+emulator_debug_log(dbg_msg, true_size, "BUZZER");
 HAL_Delay(duration);
 
 } /* emulator_buzzer_beep_request */

--- a/src/emulator_timer.c
+++ b/src/emulator_timer.c
@@ -212,7 +212,7 @@ void emulator_buzzer_beep_request
 char dbg_msg[128];
 size_t true_size = 0;
 true_size = snprintf(dbg_msg, 128, "Beeping for %d ms.", duration);
-emulator_debug_log(dbg_msg, true_size, "BUZZER");
+emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYSTEM_BUZZER);
 HAL_Delay(duration);
 
 } /* emulator_buzzer_beep_request */

--- a/src/emulator_timer.c
+++ b/src/emulator_timer.c
@@ -209,10 +209,7 @@ void emulator_buzzer_beep_request
     uint32_t duration
     )
 {
-char dbg_msg[128];
-size_t true_size = 0;
-true_size = snprintf(dbg_msg, 128, "Beeping for %d ms.", duration);
-emulator_debug_log(dbg_msg, true_size, EMULATOR_SUBSYSTEM_BUZZER);
+emulator_logf("Beeping for %d ms", EMULATOR_SUBSYSTEM_BUZZER, duration);
 HAL_Delay(duration);
 
 } /* emulator_buzzer_beep_request */

--- a/src/emulator_uart.c
+++ b/src/emulator_uart.c
@@ -156,17 +156,13 @@ bool emulator_prompt_and_open_serial_port
 {
 /* Prompt for serial port */
 char port_buf[12];
-printf("Serial Init: Please enter your serial port in the format /dev/ttyXX or in the format COMX.\n\n");
+emulator_log("Please enter your serial port in the format /dev/ttyXX or in the format COMX.", "SERIAL");
 #if defined( _WIN32 ) || defined( __CYGWIN__ )
-printf("    Note for Windows users:\n");
-printf("    COM1 maps to /dev/ttyS0\n");
-printf("    COM2 maps to /dev/ttyS1\n");
-printf("    (etc)\n");
 #endif
 printf("Input: \n");
 
 if(fgets(port_buf, sizeof(port_buf), stdin) == NULL){
-    perror("Serial Init: invalid port input\n");
+    emulator_log("Invalid port input.", "SERIAL");
     return false;
 }
 
@@ -193,7 +189,7 @@ if(strncmp(com_buf, "COM", 3) == 0){
 serial_port = open(port_buf, O_RDWR | O_NOCTTY | O_NDELAY); // Open the port
 
 if (serial_port < 0) {
-    perror("Serial Init: error opening serial port\n");
+    emulator_log("Error opening serial port.", "SERIAL");
     return false;
 }
 
@@ -201,7 +197,7 @@ struct termios tty;
 
 // Read in existing settings, handle errors
 if(tcgetattr(serial_port, &tty) != 0) {
-    perror("Serial Init: tcgetattr failed.\n");
+    emulator_log("tcgetattr failed.", "SERIAL");
     return false;
 }
 
@@ -233,16 +229,16 @@ tty.c_cc[VMIN] = 0;    // Minimum number of characters to read
 
 // Save TTY settings, handle errors
 if (tcsetattr(serial_port, TCSANOW, &tty) != 0) {
-    perror("Serial Init: tcsetattr failed.\n");
+    emulator_log("tcsetattr failed.", "SERIAL");
     return false;
 }
 
 if (fcntl(serial_port, F_GETFD) == -1) {
-    fprintf(stderr, "Serial Init: File descriptor became invalid\n");
+    emulator_log("FD became invalid.", "SERIAL");
     return false;
 }
 else {
-    printf("Serial Init: File descriptor is still valid at end of init\n");
+    emulator_log("FD remails valid at end of init.", "SERIAL");
 }
 
 return true;
@@ -293,7 +289,7 @@ static USB_STATUS serial_read
 
 // Verify fd is still valid before reading
 if (fcntl(serial_port, F_GETFD) == -1) {
-    fprintf(stderr, "Serial: Read: File descriptor became invalid\n");
+    emulator_log("Read: File descriptor became invalid.", "SERIAL");
     return USB_FAIL;
 }
 
@@ -308,7 +304,7 @@ FD_SET(serial_port, &rfds);
 
 int ret = select(serial_port + 1, &rfds, NULL, NULL, &tv);
 if (ret < 0) {
-    perror("Serial: Select Failed");
+    emulator_log("Select failed.", "SERIAL");
     return USB_FAIL;
 } else if (ret == 0) {
     return USB_TIMEOUT;
@@ -318,7 +314,7 @@ memset( rx_data_ptr, 0, rx_data_size );
 int n = read( serial_port, rx_data_ptr, rx_data_size );
     
     if (n < 0) {
-        perror("Serial: Read Failed");
+        emulator_log("Read failed.", "SERIAL");
         return USB_FAIL;
     } else if (n == 0) {
         return USB_TIMEOUT;
@@ -400,7 +396,7 @@ static void gps_read_handler_IT
 // memset( gps_data_ptr, 0, gps_data_size );
 if (message_num >= array_size( gps_msgs ) )
     {
-    printf("[GPS DEBUG] Error: index out of range\n");
+    emulator_log("Index out of range.", "GPS");
     return;
     }
 memcpy( rx_buffer, gps_msgs[message_num], strlen( gps_msgs[message_num] ) );

--- a/src/emulator_uart.c
+++ b/src/emulator_uart.c
@@ -155,13 +155,13 @@ bool emulator_prompt_and_open_serial_port
 {
 /* Prompt for serial port */
 char port_buf[12];
-emulator_log("Please enter your serial port in the format /dev/ttyXX or in the format COMX.", "SERIAL");
+emulator_log("Please enter your serial port in the format /dev/ttyXX or in the format COMX.", EMULATOR_SUBSYSTEM_SERIAL);
 #if defined( _WIN32 ) || defined( __CYGWIN__ )
 #endif
 printf("Input: \n");
 
 if(fgets(port_buf, sizeof(port_buf), stdin) == NULL){
-    emulator_log("Invalid port input.", "SERIAL");
+    emulator_log("Invalid port input.", EMULATOR_SUBSYSTEM_SERIAL);
     return false;
 }
 
@@ -188,7 +188,7 @@ if(strncmp(com_buf, "COM", 3) == 0){
 serial_port = open(port_buf, O_RDWR | O_NOCTTY | O_NDELAY); // Open the port
 
 if (serial_port < 0) {
-    emulator_log("Error opening serial port.", "SERIAL");
+    emulator_log("Error opening serial port.", EMULATOR_SUBSYSTEM_SERIAL);
     return false;
 }
 
@@ -196,7 +196,7 @@ struct termios tty;
 
 // Read in existing settings, handle errors
 if(tcgetattr(serial_port, &tty) != 0) {
-    emulator_log("tcgetattr failed.", "SERIAL");
+    emulator_log("tcgetattr failed.", EMULATOR_SUBSYSTEM_SERIAL);
     return false;
 }
 
@@ -228,16 +228,16 @@ tty.c_cc[VMIN] = 0;    // Minimum number of characters to read
 
 // Save TTY settings, handle errors
 if (tcsetattr(serial_port, TCSANOW, &tty) != 0) {
-    emulator_log("tcsetattr failed.", "SERIAL");
+    emulator_log("tcsetattr failed.", EMULATOR_SUBSYSTEM_SERIAL);
     return false;
 }
 
 if (fcntl(serial_port, F_GETFD) == -1) {
-    emulator_log("FD became invalid.", "SERIAL");
+    emulator_log("FD became invalid.", EMULATOR_SUBSYSTEM_SERIAL);
     return false;
 }
 else {
-    emulator_log("FD remails valid at end of init.", "SERIAL");
+    emulator_log("FD remails valid at end of init.", EMULATOR_SUBSYSTEM_SERIAL);
 }
 
 return true;
@@ -288,7 +288,7 @@ static USB_STATUS serial_read
 
 // Verify fd is still valid before reading
 if (fcntl(serial_port, F_GETFD) == -1) {
-    emulator_log("Read: File descriptor became invalid.", "SERIAL");
+    emulator_log("Read: File descriptor became invalid.", EMULATOR_SUBSYSTEM_SERIAL);
     return USB_FAIL;
 }
 
@@ -303,7 +303,7 @@ FD_SET(serial_port, &rfds);
 
 int ret = select(serial_port + 1, &rfds, NULL, NULL, &tv);
 if (ret < 0) {
-    emulator_log("Select failed.", "SERIAL");
+    emulator_log("Select failed.", EMULATOR_SUBSYSTEM_SERIAL);
     return USB_FAIL;
 } else if (ret == 0) {
     return USB_TIMEOUT;
@@ -313,7 +313,7 @@ memset( rx_data_ptr, 0, rx_data_size );
 int n = read( serial_port, rx_data_ptr, rx_data_size );
     
     if (n < 0) {
-        emulator_log("Read failed.", "SERIAL");
+        emulator_log("Read failed.", EMULATOR_SUBSYSTEM_SERIAL);
         return USB_FAIL;
     } else if (n == 0) {
         return USB_TIMEOUT;
@@ -395,7 +395,7 @@ static void gps_read_handler_IT
 // memset( gps_data_ptr, 0, gps_data_size );
 if (message_num >= array_size( gps_msgs ) )
     {
-    emulator_log("Index out of range.", "GPS");
+    emulator_log("Index out of range.", EMULATOR_SUBSYSTEM_GPS);
     return;
     }
 memcpy( rx_buffer, gps_msgs[message_num], strlen( gps_msgs[message_num] ) );


### PR DESCRIPTION
Sets up a unified logging interface for the emulator. Could be used in the future to support the verbose option (see #39).

Parent: https://github.com/SunDevilRocketry/Flight-Computer-Firmware/pull/277